### PR TITLE
fix(security): remove hardcoded SECRET_KEY fallback

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -6,6 +6,7 @@ Production-ready configuration for AWS deployment.
 import os
 from pathlib import Path
 from dotenv import load_dotenv
+from django.core.exceptions import ImproperlyConfigured
 
 # Load environment variables from .env file (development only)
 load_dotenv()
@@ -18,7 +19,16 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # =============================================================================
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-your-secret-key-here')
+SECRET_KEY = os.getenv('SECRET_KEY')
+if not SECRET_KEY:
+    # In DEBUG mode, use a dev-only key. In production, crash immediately.
+    if os.getenv('DEBUG', 'False').lower() in ('true', '1', 'yes'):
+        SECRET_KEY = 'django-insecure-dev-only-key-not-for-production'
+    else:
+        raise ImproperlyConfigured(
+            "SECRET_KEY environment variable is required in production. "
+            "Generate one with: python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'"
+        )
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DEBUG', 'False').lower() in ('true', '1', 'yes')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     environment:
       # Django settings
       DEBUG: "False"
-      SECRET_KEY: "${SECRET_KEY:-django-insecure-change-this-in-production}"
+      SECRET_KEY: "${SECRET_KEY:?SECRET_KEY environment variable is required. Generate with: python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'}"
       ALLOWED_HOSTS: "${DOMAIN:-localhost},backend,127.0.0.1"
       
       # Database - use 'db' as host (Docker internal network)


### PR DESCRIPTION
- Remove insecure default SECRET_KEY in settings.py
- In DEBUG mode, use a clearly-labeled dev-only key
- In production (DEBUG=False), raise ImproperlyConfigured immediately
- Update docker-compose.yml to require SECRET_KEY via :? syntax
- Include key generation command in error messages