### PR TITLE
feat(backend): add SQLite fallback for local dev without Docker

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -116,20 +116,29 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "core.wsgi.application"
 
-# --- Database (PostgreSQL) ---
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.getenv("DB_NAME", "accountsafe"),
-        "USER": os.getenv("DB_USER", "postgres"),
-        "PASSWORD": os.getenv("DB_PASSWORD", "postgres"),
-        "HOST": os.getenv("DB_HOST", "localhost"),
-        "PORT": os.getenv("DB_PORT", "5432"),
-        "OPTIONS": {
-            "options": "-c search_path=public",
-        },
+# --- Database ---
+# Use SQLite for local dev (DB_ENGINE=sqlite3), PostgreSQL otherwise
+if os.getenv("DB_ENGINE") == "sqlite3":
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.getenv("DB_NAME", "accountsafe"),
+            "USER": os.getenv("DB_USER", "postgres"),
+            "PASSWORD": os.getenv("DB_PASSWORD", "postgres"),
+            "HOST": os.getenv("DB_HOST", "localhost"),
+            "PORT": os.getenv("DB_PORT", "5432"),
+            "OPTIONS": {
+                "options": "-c search_path=public",
+            },
+        }
+    }
 
 # --- Password validation ---
 AUTH_PASSWORD_VALIDATORS = [


### PR DESCRIPTION
## Description
Set DB_ENGINE=sqlite3 to use SQLite instead of PostgreSQL, enabling the backend to run standalone without Docker or PostgreSQL installed. PostgreSQL remains the default for Docker and production deployments.