### PR TITLE
fix(nginx): render envsubst template explicitly when CMD is overridden

### DIFF
--- a/docker-compose.oracle.yml
+++ b/docker-compose.oracle.yml
@@ -124,8 +124,18 @@ services:
           memory: 512M
         reservations:
           memory: 128M
-    # Reload nginx every 6h so renewed certs are picked up without downtime.
-    command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
+    # The nginx:alpine entrypoint only runs its init scripts (including
+    # template rendering via envsubst) when $1 is `nginx` or `nginx-debug`.
+    # We override CMD with /bin/sh, so we must render templates ourselves
+    # before starting nginx. We also keep a 6-hour reload loop so certbot's
+    # renewed Let's Encrypt certs are picked up without restarting.
+    command:
+      - /bin/sh
+      - -c
+      - |
+        envsubst '$$DOMAIN' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf
+        { while :; do sleep 6h & wait $${!}; nginx -s reload 2>/dev/null || true; done; } &
+        exec nginx -g 'daemon off;'
 
   certbot:
     image: certbot/certbot:latest


### PR DESCRIPTION
The nginx:alpine entrypoint only runs its init scripts (including /docker-entrypoint.d/20-envsubst-on-templates.sh) when $1 is 'nginx' or 'nginx-debug'. Our CMD starts with /bin/sh to wrap a cert-reload loop, so template rendering was silently skipped and the default welcome config (listen 80 only) stayed in place -- port 443 had no listener and TLS connections were refused.

Fix: render the template ourselves via envsubst, then keep the existing background reload loop and exec nginx.

## Type of Change

**Select the type of change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (code restructuring without changing functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security patch

## Description

**What does this PR do?**

A clear and concise description of your changes.

## Related Issue

**Link to the issue this PR addresses:**

Closes #(issue number)

## Changes Made

**List the specific changes you've made:**

- Changed X to Y in file A
- Added new component B
- Refactored function C
- Updated documentation for D

## Screenshots

**For UI changes, provide before/after screenshots:**

### Before
<!-- Paste screenshot here -->

### After
<!-- Paste screenshot here -->

## Testing

**How has this been tested?**

- [ ] Tested on Desktop (Chrome, Firefox, Safari)
- [ ] Tested on Mobile (iOS Safari, Chrome Mobile)
- [ ] Tested on Tablet
- [ ] Added new unit tests
- [ ] All existing tests pass
- [ ] Manual testing completed

**Test scenarios:**

1. Scenario 1: Description of what you tested
2. Scenario 2: Description of what you tested

## Checklist

**Before submitting, confirm:**

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] I have checked my code and corrected any misspellings
- [ ] My commit messages follow the Conventional Commits specification

## Frontend Changes (if applicable)

- [ ] TypeScript types are properly defined
- [ ] Component uses Tailwind CSS (no inline styles)
- [ ] Responsive design tested on multiple screen sizes
- [ ] Accessibility (ARIA labels, keyboard navigation) considered
- [ ] Dark mode compatibility verified

## Backend Changes (if applicable)

- [ ] Follows PEP 8 style guide
- [ ] Database migrations created (if schema changed)
- [ ] API endpoint documentation updated
- [ ] Input validation implemented
- [ ] Security best practices followed
- [ ] No sensitive data logged

## Security Considerations

**Does this PR introduce any security concerns?**

- [ ] No security impact
- [ ] Security review required
- [ ] Handles sensitive data (encryption implemented)
- [ ] Changes authentication/authorization logic
- [ ] Adds new external dependencies

**If security-sensitive, describe the measures taken:**


## Breaking Changes

**Does this PR introduce breaking changes?**

- [ ] No
- [ ] Yes (describe below)

**If yes, describe the breaking changes and migration path:**


## Additional Notes

**Any additional information reviewers should know:**


## Deployment Notes

**Special deployment steps required:**

- [ ] No special steps needed
- [ ] Environment variables need updating
- [ ] Database migration required
- [ ] Cache needs clearing
- [ ] Other: ___

---

**Reviewer Checklist:**
- [ ] Code quality and style approved
- [ ] Tests are adequate and passing
- [ ] Documentation is clear and complete
- [ ] No security vulnerabilities introduced
- [ ] Performance impact is acceptable
