### PR TITLE
fix: expose port for connection in local 

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -12,6 +12,8 @@ services:
       POSTGRES_DB: accountsafe
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
     volumes:
       - ./pg_data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
This fixes #65 

## Title
Expose post on local for testing

## Description
When the local dev setup is done. To see the database, expose the DB port on the local machines
