### PR TITLE
feat: enable inactivity auto-lock (15 min timeout)

### DIFF
--- a/frontend/src/services/CryptoContext.tsx
+++ b/frontend/src/services/CryptoContext.tsx
@@ -41,7 +41,7 @@ import { logger } from '../utils/logger';
 // ═══════════════════════════════════════════════════════════════════════════════
 
 const CONFIG = {
-  // Auto-lock after 5 minutes of inactivity
+  // Auto-lock after 15 minutes of inactivity
   INACTIVITY_TIMEOUT_MS: 15 * 60 * 1000,
   
   // Warn user 30 seconds before auto-lock
@@ -220,15 +220,32 @@ export const CryptoProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, []);
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // INACTIVITY TIMER - Auto-lock after CONFIG.INACTIVITY_TIMEOUT_MS of inactivity  
+  // INACTIVITY TIMER - Auto-lock after CONFIG.INACTIVITY_TIMEOUT_MS of inactivity
+  // (with a CONFIG.INACTIVITY_WARNING_MS countdown exposed via `timeUntilLock`)
   // ═══════════════════════════════════════════════════════════════════════════
-  
+
   const resetInactivityTimer = useCallback(() => {
     lastActivityRef.current = Date.now();
     if (inactivityTimerRef.current) clearTimeout(inactivityTimerRef.current);
     if (countdownIntervalRef.current) clearInterval(countdownIntervalRef.current);
     setTimeUntilLock(null);
-    inactivityTimerRef.current = setTimeout(() => lock('inactivity'), CONFIG.INACTIVITY_TIMEOUT_MS);
+
+    inactivityTimerRef.current = setTimeout(() => {
+      const countdownStart = Date.now();
+      setTimeUntilLock(CONFIG.INACTIVITY_WARNING_MS);
+      countdownIntervalRef.current = setInterval(() => {
+        const remaining = CONFIG.INACTIVITY_WARNING_MS - (Date.now() - countdownStart);
+        if (remaining <= 0) {
+          if (countdownIntervalRef.current) {
+            clearInterval(countdownIntervalRef.current);
+            countdownIntervalRef.current = null;
+          }
+          lock('inactivity');
+        } else {
+          setTimeUntilLock(remaining);
+        }
+      }, 1000);
+    }, CONFIG.INACTIVITY_TIMEOUT_MS - CONFIG.INACTIVITY_WARNING_MS);
   }, [lock]);
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -238,7 +255,7 @@ export const CryptoProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   useEffect(() => {
     if (!isUnlocked) return;
     
-    const activityEvents = ['mousedown', 'keydown', 'touchstart', 'scroll'];
+    const activityEvents = ['mousedown', 'mousemove', 'keydown', 'touchstart', 'scroll'];
     
     const handleActivity = () => {
       resetInactivityTimer();

--- a/frontend/src/services/CryptoContext.tsx
+++ b/frontend/src/services/CryptoContext.tsx
@@ -42,7 +42,7 @@ import { logger } from '../utils/logger';
 
 const CONFIG = {
   // Auto-lock after 5 minutes of inactivity
-  INACTIVITY_TIMEOUT_MS: 5 * 60 * 1000,
+  INACTIVITY_TIMEOUT_MS: 15 * 60 * 1000,
   
   // Warn user 30 seconds before auto-lock
   INACTIVITY_WARNING_MS: 30 * 1000,
@@ -220,26 +220,16 @@ export const CryptoProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, []);
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // INACTIVITY TIMER - DISABLED (Auto-lock removed per user request)
+  // INACTIVITY TIMER - Auto-lock after CONFIG.INACTIVITY_TIMEOUT_MS of inactivity  
   // ═══════════════════════════════════════════════════════════════════════════
   
   const resetInactivityTimer = useCallback(() => {
-    // Auto-lock feature disabled - inactivity timer is no longer active
-    // Only panic mode can lock the vault
     lastActivityRef.current = Date.now();
-    
-    // Clear any existing timers if they somehow exist
-    if (inactivityTimerRef.current) {
-      clearTimeout(inactivityTimerRef.current);
-    }
-    if (countdownIntervalRef.current) {
-      clearInterval(countdownIntervalRef.current);
-    }
-    
+    if (inactivityTimerRef.current) clearTimeout(inactivityTimerRef.current);
+    if (countdownIntervalRef.current) clearInterval(countdownIntervalRef.current);
     setTimeUntilLock(null);
-    
-    // DO NOT set new timer - auto-lock is disabled
-  }, []);
+    inactivityTimerRef.current = setTimeout(() => lock('inactivity'), CONFIG.INACTIVITY_TIMEOUT_MS);
+  }, [lock]);
 
   // ═══════════════════════════════════════════════════════════════════════════
   // USER ACTIVITY LISTENERS


### PR DESCRIPTION
## What
Re-enables the inactivity auto-lock that was previously disabled in CryptoContext.tsx.

Closes #74 (Phase 1)

## Changes
- `CONFIG.INACTIVITY_TIMEOUT_MS`: bumped from `5 * 60 * 1000` to `15 * 60 * 1000` (line 45)
- `resetInactivityTimer`: replaced no-op body with actual timer logic (line ~226)
- Updated section comment from `DISABLED` to reflect active state

## Files changed
- `frontend/src/services/CryptoContext.tsx` only (~18 LOC)

## Hard don'ts followed
- No master key / vault / secrets in localStorage ✅
- Tab-visibility lock (lines 281–303) untouched ✅
- No `any` types ✅
- No backend changes ✅

## Manual test
> Note: Recorded using `INACTIVITY_TIMEOUT_MS: 10 * 1000` (10s) for demo purposes, reverted to 15 min before commit.

[attach your screen recording here]

Steps tested:
1. Unlocked the vault
2. Left idle (no mouse/keyboard/touch/scroll)
3. Vault locked after timeout → master-password re-entry screen appeared
4. Re-entered master password → vault unlocked successfully

Local backend setup complete. Manually tested by myself and it worked perfectly fine