### PR TITLE
feat: add zero-knowledge landing FAQ

### DIFF
--- a/frontend/src/components/SecurityFaqSection.tsx
+++ b/frontend/src/components/SecurityFaqSection.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+const faqItems = [
+  {
+    question: 'What does zero-knowledge mean in AccountSafe?',
+    answer:
+      'Sensitive vault data is encrypted in the browser before it is sent anywhere. The server stores ciphertext and cannot decrypt your vault contents.',
+  },
+  {
+    question: 'Does my master password leave my device?',
+    answer:
+      'No. The browser derives an authentication hash and encryption key locally, then sends only the derived auth hash for verification.',
+  },
+  {
+    question: 'What encryption protects vault data?',
+    answer:
+      'AccountSafe uses AES-256-GCM authenticated encryption with Argon2id key derivation, matching the security model documented in the project README.',
+  },
+  {
+    question: 'Can I export or restore my vault?',
+    answer:
+      'Yes. Export and import use encrypted vault backups, so the server still never sees decrypted vault data during backup or restore.',
+  },
+  {
+    question: 'What is duress mode?',
+    answer:
+      'Duress mode lets a secondary password reveal a decoy vault while the real vault remains protected under the primary password.',
+  },
+  {
+    question: 'How do shared secrets stay private?',
+    answer:
+      'One-time sharing encrypts content client-side. The encrypted blob can be stored by the server, while the decryption key stays in the URL fragment and is not sent to the server.',
+  },
+  {
+    question: 'Can I self-host AccountSafe?',
+    answer:
+      'Yes. The project includes Docker/local development steps and production deployment guidance for the Django backend, PostgreSQL, and hosted frontend.',
+  },
+];
+
+const SecurityFaqSection: React.FC = () => {
+  return (
+    <section className="px-4 pb-16 sm:pb-24" aria-labelledby="faq-heading">
+      <div className="mx-auto max-w-5xl border-t border-zinc-200 pt-10 dark:border-zinc-800 sm:pt-12">
+        <div className="mb-8 max-w-2xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-emerald-600 dark:text-emerald-400">
+            Security FAQ
+          </p>
+          <h2
+            id="faq-heading"
+            className="mt-3 text-2xl font-bold text-zinc-900 dark:text-white sm:text-3xl"
+          >
+            Straight answers from the security docs
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+            No fabricated reviews or usage claims. These answers reflect the documented
+            zero-knowledge vault, export, duress, sharing, and self-hosting behavior.
+          </p>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-2">
+          {faqItems.map((item) => (
+            <details
+              key={item.question}
+              className="group rounded-lg border border-zinc-200 bg-zinc-50/70 p-4 text-left dark:border-zinc-800 dark:bg-zinc-900/45"
+            >
+              <summary className="flex cursor-pointer list-none items-start justify-between gap-4 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                <span>{item.question}</span>
+                <span
+                  aria-hidden="true"
+                  className="mt-0.5 text-lg leading-none text-emerald-600 transition-transform group-open:rotate-45 dark:text-emerald-400"
+                >
+                  +
+                </span>
+              </summary>
+              <p className="mt-3 text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+                {item.answer}
+              </p>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default SecurityFaqSection;

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import SecurityFaqSection from '../components/SecurityFaqSection';
 import { CategoryManager } from '../features/vault/components';
 
 const HomePage: React.FC = () => {
@@ -11,66 +12,98 @@ const HomePage: React.FC = () => {
       {token ? (
         <CategoryManager />
       ) : (
-        <div className="flex items-start sm:items-center justify-center min-h-screen px-4 py-8 pt-8 sm:pt-0">
-          <div className="text-center max-w-2xl mx-auto">
-            {/* Hero Icon */}
-            <div className="w-16 h-16 sm:w-20 sm:h-20 mx-auto mb-6 sm:mb-8 flex items-center justify-center">
-              <div className="p-2 sm:p-2.5 bg-emerald-50 dark:bg-emerald-500/10 rounded-lg sm:rounded-xl border border-emerald-200 dark:border-emerald-500/20 overflow-hidden">
-                <img src="/logo.png" alt="AccountSafe" className="w-10 h-10 sm:w-12 sm:h-12 object-contain" />
+        <>
+          <div className="flex items-start sm:items-center justify-center min-h-screen px-4 py-8 pt-8 sm:pt-0">
+            <div className="text-center max-w-2xl mx-auto">
+              {/* Hero Icon */}
+              <div className="w-16 h-16 sm:w-20 sm:h-20 mx-auto mb-6 sm:mb-8 flex items-center justify-center">
+                <div className="p-2 sm:p-2.5 bg-emerald-50 dark:bg-emerald-500/10 rounded-lg sm:rounded-xl border border-emerald-200 dark:border-emerald-500/20 overflow-hidden">
+                  <img
+                    src="/logo.png"
+                    alt="AccountSafe"
+                    className="w-10 h-10 sm:w-12 sm:h-12 object-contain"
+                  />
+                </div>
               </div>
-            </div>
-            
-            <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-zinc-900 dark:text-white mb-3 sm:mb-4 px-4">
-              Welcome to <span className="text-blue-500 dark:text-blue-400">AccountSafe</span>
-            </h1>
-            <p className="text-sm sm:text-base md:text-lg text-zinc-600 dark:text-zinc-400 mb-8 sm:mb-10 max-w-xl mx-auto px-4">
-              Protected by AES-256-GCM authenticated encryption with Argon2id key derivation. Our zero-knowledge architecture ensures your data is encrypted securely at rest
-            </p>
-            
-            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center px-4">
-              <Link 
-                to="/login" 
-                className="px-6 sm:px-8 py-3 sm:py-3.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 rounded-lg transition-all shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40"
-              >
-                Log in to your vault
-              </Link>
-              <Link 
-                to="/register" 
-                className="px-6 sm:px-8 py-3 sm:py-3.5 text-sm font-medium text-zinc-700 dark:text-zinc-300 bg-zinc-100 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-200 dark:hover:bg-zinc-800 hover:border-zinc-300 dark:hover:border-zinc-600 transition-all"
-              >
-                Create free account
-              </Link>
-            </div>
-            
-            {/* Trust indicators */}
-            <div className="mt-10 sm:mt-12 flex flex-wrap items-center justify-center gap-4 sm:gap-6 text-xs text-zinc-600 dark:text-zinc-500 px-4">
-              <div className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-                Zero-Knowledge Architecture
+
+              <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-zinc-900 dark:text-white mb-3 sm:mb-4 px-4">
+                Welcome to <span className="text-blue-500 dark:text-blue-400">AccountSafe</span>
+              </h1>
+              <p className="text-sm sm:text-base md:text-lg text-zinc-600 dark:text-zinc-400 mb-8 sm:mb-10 max-w-xl mx-auto px-4">
+                Protected by AES-256-GCM authenticated encryption with Argon2id key derivation.
+                Our zero-knowledge architecture ensures your data is encrypted securely at rest
+              </p>
+
+              <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center px-4">
+                <Link
+                  to="/login"
+                  className="px-6 sm:px-8 py-3 sm:py-3.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 rounded-lg transition-all shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40"
+                >
+                  Log in to your vault
+                </Link>
+                <Link
+                  to="/register"
+                  className="px-6 sm:px-8 py-3 sm:py-3.5 text-sm font-medium text-zinc-700 dark:text-zinc-300 bg-zinc-100 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg hover:bg-zinc-200 dark:hover:bg-zinc-800 hover:border-zinc-300 dark:hover:border-zinc-600 transition-all"
+                >
+                  Create free account
+                </Link>
               </div>
-              <div className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-                Industry-Standard Encryption at Rest
-              </div>
-              <div className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-                Secure Credential Management
-              </div>
-              <div className="flex items-center gap-2">
-                <svg className="w-4 h-4 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                </svg>
-                Managed Security Architecture
+
+              {/* Trust indicators */}
+              <div className="mt-10 sm:mt-12 flex flex-wrap items-center justify-center gap-4 sm:gap-6 text-xs text-zinc-600 dark:text-zinc-500 px-4">
+                <div className="flex items-center gap-2">
+                  <svg
+                    className="w-4 h-4 text-green-500"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                  Zero-Knowledge Architecture
+                </div>
+                <div className="flex items-center gap-2">
+                  <svg
+                    className="w-4 h-4 text-green-500"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                  Industry-Standard Encryption at Rest
+                </div>
+                <div className="flex items-center gap-2">
+                  <svg
+                    className="w-4 h-4 text-green-500"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                  Secure Credential Management
+                </div>
+                <div className="flex items-center gap-2">
+                  <svg
+                    className="w-4 h-4 text-green-500"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                  Managed Security Architecture
+                </div>
               </div>
             </div>
           </div>
-        </div>
+          <SecurityFaqSection />
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BookOpen, ArrowRight, Check } from 'lucide-react';
 import { ButtonLink } from '../components/ui';
+import SecurityFaqSection from '../components/SecurityFaqSection';
 
 const LandingPage: React.FC = () => {
   return (
@@ -10,35 +11,36 @@ const LandingPage: React.FC = () => {
           {/* Hero Icon */}
           <div className="w-16 h-16 sm:w-20 sm:h-20 mx-auto mb-6 sm:mb-8 flex items-center justify-center">
             <div className="p-2 sm:p-2.5 bg-emerald-50 dark:bg-emerald-500/10 rounded-lg sm:rounded-xl border border-emerald-200 dark:border-emerald-500/20 overflow-hidden">
-              <img src="/logo.png" alt="AccountSafe" className="w-10 h-10 sm:w-12 sm:h-12 object-contain" />
+              <img
+                src="/logo.png"
+                alt="AccountSafe"
+                className="w-10 h-10 sm:w-12 sm:h-12 object-contain"
+              />
             </div>
           </div>
-          
+
           <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-zinc-900 dark:text-white mb-3 sm:mb-4 px-4">
             Welcome to <span className="text-primary dark:text-primary-400">AccountSafe</span>
           </h1>
           <p className="text-sm sm:text-base md:text-lg text-zinc-600 dark:text-zinc-400 mb-8 sm:mb-10 max-w-xl mx-auto px-4">
-            Protected by AES-256-GCM authenticated encryption with Argon2id key derivation. Our zero-knowledge architecture ensures your data is encrypted securely at rest
+            Protected by AES-256-GCM authenticated encryption with Argon2id key derivation. Our
+            zero-knowledge architecture ensures your data is encrypted securely at rest
           </p>
-          
+
           <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center px-4">
-            <ButtonLink 
-              to="/login" 
+            <ButtonLink
+              to="/login"
               variant="default"
               size="lg"
               className="shadow-lg shadow-primary/25 hover:shadow-primary/40"
             >
               Log in to your vault
             </ButtonLink>
-            <ButtonLink 
-              to="/register" 
-              variant="outline"
-              size="lg"
-            >
+            <ButtonLink to="/register" variant="outline" size="lg">
               Create free account
             </ButtonLink>
           </div>
-          
+
           {/* Secondary CTA - Security Architecture */}
           <div className="mt-4 sm:mt-6 flex justify-center px-4">
             <ButtonLink
@@ -51,28 +53,30 @@ const LandingPage: React.FC = () => {
               Security Architecture
             </ButtonLink>
           </div>
-          
+
           {/* Trust indicators */}
-            <div className="mt-10 sm:mt-12 flex flex-wrap items-center justify-center gap-4 sm:gap-6 text-xs text-zinc-600 dark:text-zinc-500 px-4">
-              <div className="flex items-center gap-2">
-                <Check className="w-4 h-4 text-success" />
-                Zero-Knowledge Architecture
-              </div>
-              <div className="flex items-center gap-2">
-                <Check className="w-4 h-4 text-success" />
-                Industry-Standard Encryption at Rest
-              </div>
-              <div className="flex items-center gap-2">
-                <Check className="w-4 h-4 text-success" />
-                Secure Credential Management
-              </div>
-              <div className="flex items-center gap-2">
-                <Check className="w-4 h-4 text-success" />
-                Managed Security Architecture
-              </div>
+          <div className="mt-10 sm:mt-12 flex flex-wrap items-center justify-center gap-4 sm:gap-6 text-xs text-zinc-600 dark:text-zinc-500 px-4">
+            <div className="flex items-center gap-2">
+              <Check className="w-4 h-4 text-success" />
+              Zero-Knowledge Architecture
             </div>
+            <div className="flex items-center gap-2">
+              <Check className="w-4 h-4 text-success" />
+              Industry-Standard Encryption at Rest
+            </div>
+            <div className="flex items-center gap-2">
+              <Check className="w-4 h-4 text-success" />
+              Secure Credential Management
+            </div>
+            <div className="flex items-center gap-2">
+              <Check className="w-4 h-4 text-success" />
+              Managed Security Architecture
+            </div>
+          </div>
         </div>
       </div>
+
+      <SecurityFaqSection />
     </div>
   );
 };

--- a/frontend/src/pages/__tests__/HomePage.test.tsx
+++ b/frontend/src/pages/__tests__/HomePage.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import HomePage from '../HomePage';
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    token: null,
+  }),
+}));
+
+jest.mock('../../features/vault/components', () => ({
+  CategoryManager: () => <div>Vault dashboard</div>,
+}));
+
+describe('HomePage public FAQ', () => {
+  it('renders a compact security FAQ without fabricated social proof', () => {
+    render(
+      <BrowserRouter>
+        <HomePage />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: /straight answers from the security docs/i })).toBeInTheDocument();
+    expect(screen.getByText(/what does zero-knowledge mean in accountsafe/i)).toBeInTheDocument();
+    expect(screen.getByText(/does my master password leave my device/i)).toBeInTheDocument();
+    expect(screen.getByText(/can i self-host accountsafe/i)).toBeInTheDocument();
+    expect(screen.queryByText(/testimonial/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/trusted by/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- adds a compact FAQ section to the public landing page using only claims already documented in the README/API docs
- keeps the hero as the first viewport and avoids testimonials, ratings, user counts, or conversion/social-proof claims
- uses native details/summary accordions with responsive two-column layout and no animation library
- adds a focused regression test that checks the FAQ appears and fabricated social-proof copy is absent

Closes #88

## Screenshot
![AccountSafe FAQ](https://raw.githubusercontent.com/saurabhhhcodes/AccountSafe/artifacts/faq-88-screenshot/accountsafe-faq-88.png)

## Validation
- npm ci
- npm test -- --watchAll=false --runTestsByPath src/pages/__tests__/HomePage.test.tsx
- npm run build
- git diff --check

## Notes
The remaining visible red status is Vercel team authorization, not a code or build failure. If accepted for GSSoC, please mirror the linked issue labels on this PR: gssoc26 and level 1.